### PR TITLE
Fix standalone quit

### DIFF
--- a/src/Launcher.java
+++ b/src/Launcher.java
@@ -50,7 +50,7 @@ public class Launcher {
                         client.triggerQuit();
                         try {
                             // We sleep for one frame before exiting to let the game update for the other client before closing
-                            Thread.sleep(1000/Def.FRAMES_PER_SECOND);
+                            Thread.sleep(1000 / Def.FRAMES_PER_SECOND);
                         } catch (InterruptedException ex) {
                             ex.printStackTrace();
                         }


### PR DESCRIPTION
The program will properly shut down when the window is closed while the server is not connected to any clients.

Side effect:
Before, after the player closes the window, a lose window will pop up on the player that closed the window's side. Now it won't pop up anymore, but the program will still properly shutdown even it's not connected.